### PR TITLE
Enhance parser with unquoted interpolated value support and refactoring

### DIFF
--- a/.changeset/fast-garlics-cry.md
+++ b/.changeset/fast-garlics-cry.md
@@ -1,0 +1,5 @@
+---
+"elemental-js": minor
+---
+
+feat(parser): Enhanced parser with single interpolated value support and improved variable naming for better readability.

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "printWidth": 100
 }

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -118,13 +118,14 @@ export function parse(strings, ...interpolations) {
               pushToAttributeValue(globalBuffer)
               clearBuffer()
             }
-            if (endOfString) {
+            if (endOfString)
               pushToAttributeValue(interpolations[stringIndex])
-            } else setState(ParserState.WHITESPACE)
+            else setState(ParserState.WHITESPACE)
             break
           }
           pushToBuffer(char)
-          break;
+          break
+
         case ParserState.CONTENT:
           if (endOfString || isEndQuote(char)) {
             if (globalBuffer) {

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -20,24 +20,16 @@ export function parse(strings, ...interpolations) {
     content: []
   }
 
-  const setState = (newState) => {
-    currentState = newState
-  }
-  const setSingleQuoted = (char) => {
-    return (isSingleQuoted = isSingleQuote(char))
-  }
-  const isEndQuote = (char) => {
-    return isSingleQuoted ? isSingleQuote(char) : char === '"'
-  }
-  const pushToBuffer = (char) => {
-    globalBuffer += char
-  }
-  const clearBuffer = () => {
-    globalBuffer = ''
-  }
-  const isBufferEmpty = () => {
-    return globalBuffer === ''
-  }
+  const setState = (newState) => (currentState = newState)
+  const setSingleQuoted = (char) => (isSingleQuoted = isSingleQuote(char))
+  const isEndQuote = (char) => (isSingleQuoted ? isSingleQuote(char) : char === '"')
+  const pushToBuffer = (char) => (globalBuffer += char)
+  const isBufferEmpty = () => globalBuffer === ''
+  const clearBuffer = () => (globalBuffer = '')
+  const pushToAttributeValue = (value) => result.attributes[attributeNameBuffer].push(value)
+  const pushToContent = (value) => result.content.push(value)
+  const parsingAttributeValue = () => currentState === ParserState.ATTRIBUTE_VALUE
+
   const setTag = () => {
     result.tag = globalBuffer
     clearBuffer()
@@ -46,12 +38,6 @@ export function parse(strings, ...interpolations) {
     result.attributes[globalBuffer] = []
     attributeNameBuffer = globalBuffer
     clearBuffer()
-  }
-  const pushToAttributeValue = (value) => {
-    result.attributes[attributeNameBuffer].push(value)
-  }
-  const pushToContent = (value) => {
-    result.content.push(value)
   }
 
   strings.forEach((string, stringIndex) => {
@@ -64,9 +50,10 @@ export function parse(strings, ...interpolations) {
       switch (currentState) {
         case ParserState.TAG:
           if (isWhitespace(char)) {
-            if (isBufferEmpty()) break
-            setTag()
-            setState(ParserState.WHITESPACE)
+            if (!isBufferEmpty()) {
+              setTag()
+              setState(ParserState.WHITESPACE)
+            }
             break
           }
           if (endOfString) {
@@ -112,32 +99,20 @@ export function parse(strings, ...interpolations) {
           pushToBuffer(char)
           break
 
-        case ParserState.ATTRIBUTE_VALUE:
+        default:
           if (endOfString || isEndQuote(char)) {
             if (globalBuffer) {
-              pushToAttributeValue(globalBuffer)
+              parsingAttributeValue()
+                ? pushToAttributeValue(globalBuffer)
+                : pushToContent(globalBuffer)
               clearBuffer()
             }
-            if (endOfString)
-              pushToAttributeValue(interpolations[stringIndex])
-            else setState(ParserState.WHITESPACE)
-            break
-          }
-          pushToBuffer(char)
-          break
-
-        case ParserState.CONTENT:
-          if (endOfString || isEndQuote(char)) {
-            if (globalBuffer) {
-              pushToContent(globalBuffer)
-              clearBuffer()
-            }
-            if (endOfString) pushToContent(interpolations[stringIndex])
-            else setState(ParserState.WHITESPACE)
-            break
-          }
-          pushToBuffer(char)
-          break
+            if (endOfString) {
+              parsingAttributeValue()
+                ? pushToAttributeValue(interpolations[stringIndex])
+                : pushToContent(interpolations[stringIndex])
+            } else setState(ParserState.WHITESPACE)
+          } else pushToBuffer(char)
       }
     }
   })

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -27,8 +27,8 @@ export function parse(strings, ...interpolations) {
   const isBufferEmpty = () => globalBuffer === ''
   const clearBuffer = () => (globalBuffer = '')
   const pushToAttributeValue = (value) => result.attributes[attributeNameBuffer].push(value)
-  const pushToContent = (value) => result.content.push(value)
   const parsingAttributeValue = () => currentState === ParserState.ATTRIBUTE_VALUE
+  const pushToContent = (value) => result.content.push(value)
 
   const setTag = () => {
     result.tag = globalBuffer

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -1,6 +1,6 @@
-import { isQuote, isWhitespace, isAlphabetic } from './utilities'
+import { isQuote, isSingleQuote, isWhitespace, isAlphabetic } from './utilities'
 
-const State = {
+const ParserState = {
   TAG: 0,
   WHITESPACE: 1,
   ATTRIBUTE: 2,
@@ -8,11 +8,11 @@ const State = {
   CONTENT: 4
 }
 
-export function parse(strings, interpolations) {
-  let state = State.TAG
-  let singleQuote = false
-  let attribute = ''
-  let buffer = ''
+export function parse(strings, ...interpolations) {
+  let currentState = ParserState.TAG
+  let isSingleQuoted = false
+  let attributeNameBuffer = ''
+  let globalBuffer = ''
 
   const result = {
     tag: '',
@@ -20,20 +20,38 @@ export function parse(strings, interpolations) {
     content: []
   }
 
-  const setTag = () => {
-    result.tag = buffer
-    buffer = ''
+  const setState = (newState) => {
+    currentState = newState
   }
-  const addAttribute = () => {
-    result.attributes[buffer] = []
-    attribute = buffer
-    buffer = ''
-  }
-  const attributePushValue = (value) => {
-    result.attributes[attribute].push(value)
+  const setSingleQuoted = (char) => {
+    return (isSingleQuoted = isSingleQuote(char))
   }
   const isEndQuote = (char) => {
-    return singleQuote ? char === "'" : char === '"'
+    return isSingleQuoted ? isSingleQuote(char) : char === '"'
+  }
+  const pushToBuffer = (char) => {
+    globalBuffer += char
+  }
+  const clearBuffer = () => {
+    globalBuffer = ''
+  }
+  const isBufferEmpty = () => {
+    return globalBuffer === ''
+  }
+  const setTag = () => {
+    result.tag = globalBuffer
+    clearBuffer()
+  }
+  const addAttribute = () => {
+    result.attributes[globalBuffer] = []
+    attributeNameBuffer = globalBuffer
+    clearBuffer()
+  }
+  const pushToAttributeValue = (value) => {
+    result.attributes[attributeNameBuffer].push(value)
+  }
+  const pushToContent = (value) => {
+    result.content.push(value)
   }
 
   strings.forEach((string, stringIndex) => {
@@ -43,82 +61,82 @@ export function parse(strings, interpolations) {
       const endOfString = charIndex === endIndex
       const char = string.charAt(charIndex)
 
-      switch (state) {
-        case State.TAG:
+      switch (currentState) {
+        case ParserState.TAG:
           if (isWhitespace(char)) {
-            if (buffer === '') continue
+            if (isBufferEmpty()) break
             setTag()
-            state = State.WHITESPACE
-            continue
+            setState(ParserState.WHITESPACE)
+            break
           }
           if (endOfString) {
-            if (buffer === '') throw Error(`Tag is not defined`)
+            if (isBufferEmpty()) throw Error('Tag is not defined')
             setTag()
             return result
           }
-          buffer += char
-          continue
+          pushToBuffer(char)
+          break
 
-        case State.WHITESPACE:
+        case ParserState.WHITESPACE:
           if (isAlphabetic(char)) {
-            buffer += char
-            state = State.ATTRIBUTE
+            pushToBuffer(char)
+            setState(ParserState.ATTRIBUTE)
           } else if (isQuote(char)) {
-            singleQuote = char === "'"
-            state = State.CONTENT
+            setSingleQuoted(char)
+            setState(ParserState.CONTENT)
           }
-          continue
+          break
 
-        case State.ATTRIBUTE:
+        case ParserState.ATTRIBUTE:
           if (endOfString || isWhitespace(char)) {
             addAttribute()
-            attributePushValue(true)
+            pushToAttributeValue(true)
             if (endOfString) return result
-            state = State.WHITESPACE
-            continue
+            setState(ParserState.WHITESPACE)
+            break
           }
           if (char === '=') {
             addAttribute()
-            const nextIndex = charIndex + 1
-            const nextChar = string.charAt(nextIndex)
+            const nextCharIndex = charIndex + 1
+            const nextChar = string.charAt(nextCharIndex)
             if (isQuote(nextChar)) {
-              charIndex = nextIndex
-              singleQuote = nextChar === "'"
-              state = State.ATTRIBUTE_VALUE
+              charIndex = nextCharIndex
+              setSingleQuoted(nextChar)
+              setState(ParserState.ATTRIBUTE_VALUE)
             } else {
-              attributePushValue(interpolations[stringIndex])
-              state = State.WHITESPACE
+              pushToAttributeValue(interpolations[stringIndex])
+              setState(ParserState.WHITESPACE)
             }
-            continue
+            break
           }
-          buffer += char
-          continue
+          pushToBuffer(char)
+          break
 
-        case State.ATTRIBUTE_VALUE:
+        case ParserState.ATTRIBUTE_VALUE:
           if (endOfString || isEndQuote(char)) {
-            if (buffer) {
-              attributePushValue(buffer)
-              buffer = ''
+            if (globalBuffer) {
+              pushToAttributeValue(globalBuffer)
+              clearBuffer()
             }
-            if (endOfString) attributePushValue(interpolations[stringIndex])
-            else state = State.WHITESPACE
-            continue
+            if (endOfString) {
+              pushToAttributeValue(interpolations[stringIndex])
+            } else setState(ParserState.WHITESPACE)
+            break
           }
-          buffer += char
-          continue
-
-        case State.CONTENT:
+          pushToBuffer(char)
+          break;
+        case ParserState.CONTENT:
           if (endOfString || isEndQuote(char)) {
-            if (buffer) {
-              result.content.push(buffer)
-              buffer = ''
+            if (globalBuffer) {
+              pushToContent(globalBuffer)
+              clearBuffer()
             }
-            if (endOfString) result.content.push(interpolations[stringIndex])
-            else state = State.WHITESPACE
-            continue
+            if (endOfString) pushToContent(interpolations[stringIndex])
+            else setState(ParserState.WHITESPACE)
+            break
           }
-          buffer += char
-          continue
+          pushToBuffer(char)
+          break
       }
     }
   })

--- a/lib/src/utilities.js
+++ b/lib/src/utilities.js
@@ -1,5 +1,10 @@
+export function isSingleQuote(char) {
+  // eslint-disable-next-line quotes
+  return char === "'"
+}
+
 export function isQuote(char) {
-  return char === '"' || char === "'"
+  return char === '"' || isSingleQuote(char)
 }
 
 export function isWhitespace(char) {

--- a/lib/test/parser.test.js
+++ b/lib/test/parser.test.js
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest'
+import { parse } from '../src/parser'
+
+describe('Syntax', () => {
+  it('parses a boolean attribute and content written in one line', () => {
+    const result = parse`div data-attribute "Hello World!"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-attribute': [true]
+      },
+      content: ['Hello World!']
+    })
+  })
+
+  it('parses an attribute with explicit value and content written in one line', () => {
+    const result = parse`div data-attribute="value" "Hello World!"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-attribute': ['value']
+      },
+      content: ['Hello World!']
+    })
+  })
+
+  it('parses the tag, attribute and content split to different lines', () => {
+    const result = parse`div
+      data-attribute
+      "Hello World!"
+    `
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-attribute': [true]
+      },
+      content: ['Hello World!']
+    })
+  })
+
+  it('parses the tag, content and attribute split to different lines', () => {
+    const result = parse`div
+      "Hello World!"
+      data-attribute
+    `
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-attribute': [true]
+      },
+      content: ['Hello World!']
+    })
+  })
+})
+
+describe('Tag parsing', () => {
+  it('parses basic div tag', () => {
+    const result = parse`div`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: []
+    })
+  })
+
+  it('parses a custom element tag', () => {
+    const result = parse`custom-element`
+    expect(result).toStrictEqual({
+      tag: 'custom-element',
+      attributes: {},
+      content: []
+    })
+  })
+
+  it('throws if a tag is not defined', () => {
+    const testParsingUndefinedTag = () => parse``
+    expect(testParsingUndefinedTag).toThrow('Tag is not defined')
+  })
+})
+
+describe('Attribute parsing', () => {
+  it('parses div with data attribute and explicit value', () => {
+    const result = parse`div data-attribute="value"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'data-attribute': ['value'] },
+      content: []
+    })
+  })
+
+  it('parses div with unquoted data attribute and explicit value', () => {
+    const value = 'value'
+    const result = parse`div data-attribute=${value}`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'data-attribute': ['value'] },
+      content: []
+    })
+  })
+
+  it('parses div with boolean data attribute', () => {
+    const result = parse`div data-attribute`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'data-attribute': [true] },
+      content: []
+    })
+  })
+
+  it('parses div with explicit boolean data attribute', () => {
+    const result = parse`div data-attribute=${true}`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'data-attribute': [true] },
+      content: []
+    })
+  })
+
+  it('parses div with style attribute containing interpolated color value', () => {
+    const red = 'red'
+    const result = parse`div style="color: ${red};"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { style: ['color: ', 'red', ';'] },
+      content: []
+    })
+  })
+
+  it('parses div with multiple data attributes', () => {
+    const result = parse`div data-first="first" data-second="second"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-first': ['first'],
+        'data-second': ['second']
+      },
+      content: []
+    })
+  })
+
+  it('parses element with mixed boolean and valued attributes', () => {
+    const result = parse`input disabled type="checkbox" checked=${true}`
+    expect(result).toStrictEqual({
+      tag: 'input',
+      attributes: {
+        checked: [true],
+        disabled: [true],
+        type: ['checkbox']
+      },
+      content: []
+    })
+  })
+
+  it('parses element with custom attribute containing special characters', () => {
+    const result = parse`div data-value="Complex@Value#100"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-value': ['Complex@Value#100']
+      },
+      content: []
+    })
+  })
+
+  it('parses element with data attribute containing JSON object as a string', () => {
+    const json = '{"name":"John","age":30}'
+    const result = parse`div data-user=${json}`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-user': ['{"name":"John","age":30}']
+      },
+      content: []
+    })
+  })
+
+  it('parses attributes with various data types', () => {
+    const number = 42
+    const bool = true
+    const obj = { key: 'value' }
+    const result = parse`div data-number=${number} data-bool=${bool} data-obj=${obj}`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {
+        'data-number': [42],
+        'data-bool': [true],
+        'data-obj': [{ key: 'value' }]
+      },
+      content: []
+    })
+  })
+
+  it('parses class attribute with multiple classes', () => {
+    const result = parse`div class="class1 class2 class3"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { class: ['class1 class2 class3'] },
+      content: []
+    })
+  })
+
+  it('parses data attributes with array values', () => {
+    const array = [1, 2, 3]
+    const result = parse`div data-array="${array}"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'data-array': [[1, 2, 3]] },
+      content: []
+    })
+  })
+
+  it('parses attributes with namespace', () => {
+    const result = parse`div xml:lang="en"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: { 'xml:lang': ['en'] },
+      content: []
+    })
+  })
+})
+
+describe('Content parsing', () => {
+  it('parses div with static content', () => {
+    const result = parse`div "Hello World!"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: ['Hello World!']
+    })
+  })
+
+  it('parses div with content containing interpolated values', () => {
+    const elemental = 'Elemental'
+    const result = parse`div "Hello ${elemental} World!"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: ['Hello ', 'Elemental', ' World!']
+    })
+  })
+
+  it('parses elements with special characters in content', () => {
+    const result = parse`div "&lt;script&gt;alert('Hello')&lt;/script&gt;"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: ["&lt;script&gt;alert('Hello')&lt;/script&gt;"]
+    })
+  })
+
+  it('parses elements with numeric content', () => {
+    const number = 123
+    const result = parse`div "${number}"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: [123]
+    })
+  })
+
+  it('parses elements with mixed content types', () => {
+    const num = 42
+    const result = parse`div "Text ${num} and more text"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: ['Text ', 42, ' and more text']
+    })
+  })
+
+  it('parses elements with multiline content', () => {
+    const result = parse`div "Line 1\nLine 2\nLine 3"`
+    expect(result).toStrictEqual({
+      tag: 'div',
+      attributes: {},
+      content: ['Line 1\nLine 2\nLine 3']
+    })
+  })
+})

--- a/lib/test/parser.test.js
+++ b/lib/test/parser.test.js
@@ -174,7 +174,7 @@ describe('Attribute parsing', () => {
     })
   })
 
-  it('parses attributes with various data types', () => {
+  it('parses multiple unquoted attributes with various data types', () => {
     const number = 42
     const bool = true
     const obj = { key: 'value' }

--- a/lib/test/placeholder.test.js
+++ b/lib/test/placeholder.test.js
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest'
-
-describe('Placeholder', () => {
-  it('You shall pass!', () => {
-    expect(true).toBe(true)
-  })
-})


### PR DESCRIPTION
This PR introduces an enhancement to the parser, adding support for single interpolated values to be included unquoted. It also includes a refactor of the parser, aiming to improve readability and maintainability of the code. Furthermore, tests have been added to ensure the reliability of the new features.